### PR TITLE
Fix missing glyphs property in flight plan labels

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -297,6 +297,7 @@ const map = new mapgl.Map({
 	}),
 	style: {
 		version: 8,
+		glyphs: 'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf',
 		sources: {
 			seamlessphoto: {
 				type: 'raster',


### PR DESCRIPTION
Add OpenMapTiles font server URL to the style definition to enable text-field usage in layers like flight-plan-waypoint-labels. Without this property, MapLibre throws an error when trying to render text labels.