### PR TITLE
Fix Vite build command not found error

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# Check that package.json uses pnpm (not npm/yarn)
+pnpm run check:pkg-manager
+
 pnpm run fix

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+auto-install-peers=true

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
 	"name": "maplibre-gl-gsi-terrain",
 	"version": "2.2.2",
 	"type": "module",
+	"packageManager": "pnpm@10.23.0",
+	"engines": {
+		"node": ">=18.0.0",
+		"pnpm": ">=9.0.0"
+	},
 	"main": "./dist/terrain.js",
 	"types": "./dist/terrain.d.ts",
 	"files": [
@@ -31,8 +36,10 @@
 		"type-check": "tsc --noEmit",
 		"security:audit": "pnpm audit --audit-level moderate",
 		"security:snyk": "snyk test",
-		"ci:check": "pnpm lint && pnpm type-check && pnpm format:check && pnpm test:ci",
+		"check:pkg-manager": "node scripts/check-package-manager.mjs",
+		"ci:check": "pnpm check:pkg-manager && pnpm lint && pnpm type-check && pnpm format:check && pnpm test:ci",
 		"ci:build": "pnpm build && pnpm build:example",
+		"preinstall": "npx only-allow pnpm",
 		"postinstall": "husky"
 	},
 	"devDependencies": {

--- a/scripts/check-package-manager.mjs
+++ b/scripts/check-package-manager.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/**
+ * This script checks that package.json does not contain npm or yarn commands.
+ * This is a safeguard against accidentally introducing npm/yarn dependencies
+ * in a pnpm-only project.
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const packageJsonPath = join(process.cwd(), 'package.json')
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+
+const errors = []
+
+// Check that packageManager field exists and specifies pnpm
+if (!packageJson.packageManager) {
+	errors.push('Missing "packageManager" field in package.json')
+} else if (!packageJson.packageManager.startsWith('pnpm@')) {
+	errors.push(`Invalid packageManager: "${packageJson.packageManager}" (must start with "pnpm@")`)
+}
+
+// Check scripts for npm/yarn usage
+if (packageJson.scripts) {
+	for (const [name, script] of Object.entries(packageJson.scripts)) {
+		// Check for npm run, npm install, etc.
+		if (/\bnpm\s+(run|install|ci|exec|start|test|build)\b/i.test(script)) {
+			errors.push(`Script "${name}" uses npm: "${script}"`)
+		}
+		// Check for yarn commands
+		if (/\byarn\s+(run|install|add|exec|start|test|build)?\b/i.test(script)) {
+			errors.push(`Script "${name}" uses yarn: "${script}"`)
+		}
+	}
+}
+
+if (errors.length > 0) {
+	console.error('\n❌ Package manager check failed!\n')
+	console.error('This project uses pnpm exclusively. The following issues were found:\n')
+	errors.forEach(error => console.error(`  • ${error}`))
+	console.error('\nPlease fix these issues and try again.\n')
+	process.exit(1)
+}
+
+console.log('✅ Package manager check passed')


### PR DESCRIPTION
Add multiple safeguards to prevent npm/yarn usage:
- Add packageManager field to package.json for Corepack/Vercel detection
- Add engines field requiring pnpm >=9.0.0
- Add preinstall script with only-allow to block npm/yarn install
- Create .npmrc with engine-strict=true
- Add check:pkg-manager script to detect npm/yarn in scripts
- Add package manager check to pre-commit hook and CI checks

This prevents the Vercel deploy error where npm was used instead of pnpm, causing "vite: command not found" build failures.