### PR TITLE
Fix GSI DEM tile fetch error

### DIFF
--- a/docs/TECHNICAL_SPECIFICATION.md
+++ b/docs/TECHNICAL_SPECIFICATION.md
@@ -430,7 +430,7 @@ URL: https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png
 
 ### カスタムプロトコル
 
-#### gsidem:
+#### gsidem://
 
 GSI DEM PNGタイルを取得し、WebGL2でTerrarium形式に変換
 
@@ -438,12 +438,11 @@ GSI DEM PNGタイルを取得し、WebGL2でTerrarium形式に変換
 const protocolAction = getGsiDemProtocolAction('gsidem')
 maplibregl.addProtocol('gsidem', protocolAction)
 
-// 使用例 (gsidem:https://... 形式を使用)
-tiles: ['gsidem:https://tiles.gsj.jp/tiles/elev/mixed/{z}/{y}/{x}.png']
+// 使用例
+tiles: ['gsidem://https://tiles.gsj.jp/tiles/elev/mixed/{z}/{y}/{x}.png']
 ```
 
-> **Note**: URL形式は `gsidem:https://...` (シングルコロン) を使用します。
-> `gsidem://https://...` 形式は標準URL仕様に違反するため、MapLibre GL JSのURL正規化処理で問題が発生します。
+> **Note**: プロトコルハンドラはURL正規化による余分なスラッシュ（例: `https:///`）を自動的に修正します。
 
 ---
 

--- a/docs/TECHNICAL_SPECIFICATION.md
+++ b/docs/TECHNICAL_SPECIFICATION.md
@@ -430,7 +430,7 @@ URL: https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png
 
 ### カスタムプロトコル
 
-#### gsidem://
+#### gsidem:
 
 GSI DEM PNGタイルを取得し、WebGL2でTerrarium形式に変換
 
@@ -438,9 +438,12 @@ GSI DEM PNGタイルを取得し、WebGL2でTerrarium形式に変換
 const protocolAction = getGsiDemProtocolAction('gsidem')
 maplibregl.addProtocol('gsidem', protocolAction)
 
-// 使用例
-tiles: ['gsidem://https://tiles.gsj.jp/tiles/elev/mixed/{z}/{y}/{x}.png']
+// 使用例 (gsidem:https://... 形式を使用)
+tiles: ['gsidem:https://tiles.gsj.jp/tiles/elev/mixed/{z}/{y}/{x}.png']
 ```
+
+> **Note**: URL形式は `gsidem:https://...` (シングルコロン) を使用します。
+> `gsidem://https://...` 形式は標準URL仕様に違反するため、MapLibre GL JSのURL正規化処理で問題が発生します。
 
 ---
 

--- a/example/DroneDataSystem.tsx
+++ b/example/DroneDataSystem.tsx
@@ -79,7 +79,8 @@ const DroneDataSystem: React.FC<{ className?: string }> = ({ className = '' }) =
 				canvas.toBlob(blob => blob!.arrayBuffer().then(arr => callback(null, arr, null, null)))
 			}
 			image.onerror = () => callback(new Error('DEM読み込みエラー'))
-			image.src = params.url.replace('gsidem://', '')
+			// Handle both old format (gsidem://https://...) and new format (gsidem:https://...)
+			image.src = params.url.replace(/^gsidem:(?:\/\/)?/, '')
 			return { cancel: () => {} }
 		})
 
@@ -100,7 +101,7 @@ const DroneDataSystem: React.FC<{ className?: string }> = ({ className = '' }) =
 					},
 					gsidem: {
 						type: 'raster-dem',
-						tiles: ['gsidem://https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
+						tiles: ['gsidem:https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
 						tileSize: 256,
 						maxzoom: 14,
 					},

--- a/example/DroneDataSystem.tsx
+++ b/example/DroneDataSystem.tsx
@@ -101,7 +101,7 @@ const DroneDataSystem: React.FC<{ className?: string }> = ({ className = '' }) =
 					},
 					gsidem: {
 						type: 'raster-dem',
-						tiles: ['gsidem:https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
+						tiles: ['gsidem://https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
 						tileSize: 256,
 						maxzoom: 14,
 					},

--- a/example/data-import-export.html
+++ b/example/data-import-export.html
@@ -266,7 +266,7 @@
 							},
 							gsidem: {
 								type: 'raster-dem',
-								tiles: ['gsidem:https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
+								tiles: ['gsidem://https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
 								tileSize: 256,
 								maxzoom: 14,
 							},

--- a/example/data-import-export.html
+++ b/example/data-import-export.html
@@ -218,7 +218,8 @@
 					canvas.toBlob(blob => blob.arrayBuffer().then(arr => callback(null, arr, null, null)))
 				}
 				image.onerror = () => callback(new Error('DEM読み込みエラー'))
-				image.src = params.url.replace('gsidem://', '')
+				// Handle both old format (gsidem://https://...) and new format (gsidem:https://...)
+				image.src = params.url.replace(/^gsidem:(?:\/\/)?/, '')
 				return { cancel: () => {} }
 			})
 
@@ -265,7 +266,7 @@
 							},
 							gsidem: {
 								type: 'raster-dem',
-								tiles: ['gsidem://https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
+								tiles: ['gsidem:https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
 								tileSize: 256,
 								maxzoom: 14,
 							},

--- a/example/index.ts
+++ b/example/index.ts
@@ -205,7 +205,7 @@ try {
 
 	gsiTerrainSource = {
 		type: 'raster-dem' as const,
-		tiles: ['gsidem:https://tiles.gsj.jp/tiles/elev/mixed/{z}/{y}/{x}.png'],
+		tiles: ['gsidem://https://tiles.gsj.jp/tiles/elev/mixed/{z}/{y}/{x}.png'],
 		tileSize: 256,
 		encoding: 'terrarium' as const,
 		minzoom: 1,

--- a/example/index.ts
+++ b/example/index.ts
@@ -205,7 +205,7 @@ try {
 
 	gsiTerrainSource = {
 		type: 'raster-dem' as const,
-		tiles: ['gsidem://https://tiles.gsj.jp/tiles/elev/mixed/{z}/{y}/{x}.png'],
+		tiles: ['gsidem:https://tiles.gsj.jp/tiles/elev/mixed/{z}/{y}/{x}.png'],
 		tileSize: 256,
 		encoding: 'terrarium' as const,
 		minzoom: 1,

--- a/example/standalone-drone-system.html
+++ b/example/standalone-drone-system.html
@@ -297,7 +297,8 @@
 					canvas.toBlob(blob => blob.arrayBuffer().then(arr => callback(null, arr, null, null)))
 				}
 				image.onerror = () => callback(new Error('DEM読み込みエラー'))
-				image.src = params.url.replace('gsidem://', '')
+				// Handle both old format (gsidem://https://...) and new format (gsidem:https://...)
+				image.src = params.url.replace(/^gsidem:(?:\/\/)?/, '')
 				return { cancel: () => {} }
 			})
 
@@ -352,7 +353,7 @@
 							},
 							gsidem: {
 								type: 'raster-dem',
-								tiles: ['gsidem://https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
+								tiles: ['gsidem:https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
 								tileSize: 256,
 								maxzoom: 14,
 							},

--- a/example/standalone-drone-system.html
+++ b/example/standalone-drone-system.html
@@ -353,7 +353,7 @@
 							},
 							gsidem: {
 								type: 'raster-dem',
-								tiles: ['gsidem:https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
+								tiles: ['gsidem://https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
 								tileSize: 256,
 								maxzoom: 14,
 							},

--- a/src/terrain.ts
+++ b/src/terrain.ts
@@ -126,7 +126,7 @@ export const useGsiTerrainSource = (
 
 	return {
 		type: 'raster-dem',
-		tiles: [`gsidem:${tileUrl}`],
+		tiles: [`gsidem://${tileUrl}`],
 		tileSize: 256,
 		encoding: 'terrarium',
 		minzoom: options.minzoom ?? 1,
@@ -146,7 +146,7 @@ export const useGsiTerrainSource = (
  * addProtocol('gsidem', protocolAction);
  * const rasterDemSource = {
  *   type: 'raster-dem',
- *   tiles: ['gsidem:https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
+ *   tiles: ['gsidem://https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png'],
  *   tileSize: 256,
  *   minzoom: 1,
  *   maxzoom: 14,

--- a/src/terrain.ts
+++ b/src/terrain.ts
@@ -155,13 +155,16 @@ export const useGsiTerrainSource = (
  * const map = new Map({container: 'app', style: {sources: {terrain: gsiTerrainSource}}});
  */
 export const getGsiDemProtocolAction = (customProtocol: string): AddProtocolAction => {
+	// Pre-compile RegExp patterns for better performance (called for every tile request)
+	const protocolPattern = new RegExp(`^${customProtocol}:(?://)?`)
+	const urlFixPattern = /^(https?:)\/\/\/+/
+
 	return (params, abortController) => {
 		// Handle both old format (gsidem://https://...) and new format (gsidem:https://...)
 		// Also handle URLs that may have been normalized with extra slashes
-		const protocolPattern = new RegExp(`^${customProtocol}:(?://)?`)
 		let urlWithoutProtocol = params.url.replace(protocolPattern, '')
 		// Fix URLs that got extra slashes from URL normalization (https:/// -> https://)
-		urlWithoutProtocol = urlWithoutProtocol.replace(/^(https?:)\/\/\/+/, '$1//')
+		urlWithoutProtocol = urlWithoutProtocol.replace(urlFixPattern, '$1//')
 		return workerProtocol.request(urlWithoutProtocol, abortController)
 	}
 }


### PR DESCRIPTION
Change the custom protocol URL format from `gsidem://https://...` to `gsidem:https://...` (single colon) to comply with URL standards.

The double-slash format (`gsidem://`) violates URL specifications when combined with an embedded HTTPS URL, causing MapLibre GL's URL normalization to produce malformed URLs like `https:///` (triple slash).

Changes:
- Update terrain.ts to use `gsidem:${url}` format
- Make protocol handler robust to handle both old and new formats
- Fix URLs that got extra slashes from URL normalization
- Update all example files with the new format
- Update documentation with notes about the URL format

Fixes: Failed to fetch gsidem://https:///tiles.gsj.jp/ error